### PR TITLE
Add initial project configuration files and .gitignore

### DIFF
--- a/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/.gitignore
+++ b/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.SauceDemoAutomation.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/AndroidProjectSystem.xml
+++ b/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="RiderAndroidProjectSystem" />
+  </component>
+</project>

--- a/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/aws.xml
+++ b/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/aws.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:vakerin" />
+      </list>
+    </option>
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/encodings.xml
+++ b/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/git_toolbox_blame.xml
+++ b/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/git_toolbox_blame.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxBlameSettings">
+    <option name="version" value="2" />
+  </component>
+</project>

--- a/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/indexLayout.xml
+++ b/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/vcs.xml
+++ b/SauceDemoAutomation/.idea/.idea.SauceDemoAutomation/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
## Summary by Sourcery

Add initial project configuration including IntelliJ .idea files and a .gitignore

Chores:
- Add IntelliJ project configuration files under .idea
- Introduce a .gitignore to exclude IDE-specific files